### PR TITLE
Specify lens and incl to augeas

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,8 @@ define etc_services (
   }
 
   augeas { "${service_name}_${protocol}":
-    context => '/files/etc/services',
+    incl    => '/etc/services',
+    lens    => 'Services.lns',
     changes => $augeas_operations
   }
 }


### PR DESCRIPTION
Specifying a lens and incl stops augeas types from parsing
very many files and results in significant speed up.

https://docs.puppet.com/puppet/latest/types/augeas.html#augeas-attribute-incl